### PR TITLE
ci(github): cache models in workflow test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache ollama
+        uses: actions/cache@v4
+        with:
+          path: ~/.ollama
+          key: ${{ runner.os }}-ollama
+
       - name: Run action
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Run a prompt against a [model](https://ollama.com/library):
 - run: ollama run tinyllama "What's a large language model?"
 ```
 
+Cache the model to speed up CI:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: ~/.ollama
+    key: ${{ runner.os }}-ollama
+
+- run: ollama run tinyllama 'Define cache'
+```
+
 See [action.yml](action.yml).
 
 ## Inputs


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): cache models in workflow test.yml

Closes #40

## What is the current behavior?

Ollama models are downloaded each time test runs

## What is the new behavior?

Ollama models are cached

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation