### PR TITLE
ci(github): replace version 0.23.0 with latest in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: [0.13.5, 0.23.0]
+        version: [0.13.5, latest]
+    env:
+      VERSION: ${{ matrix.version }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Get version
+        if: matrix.version == 'latest'
+        shell: bash
+        run: echo "VERSION=$(awk '/default:/{print $2; exit}' action.yml)" >> "$GITHUB_ENV"
 
       - name: Cache ollama
         uses: actions/cache@v5
@@ -59,7 +66,7 @@ jobs:
       - name: Run action
         uses: ./
         with:
-          version: ${{ matrix.version }}
+          version: ${{ env.VERSION }}
           name: ollama-cli
 
       - name: Locate binary
@@ -68,7 +75,7 @@ jobs:
       - name: Check version
         shell: bash
         run: |
-          if [[ "$(ollama-cli --version)" != *'${{ matrix.version }}'* ]]; then
+          if [[ "$(ollama-cli --version)" != *'${{ env.VERSION }}'* ]]; then
             echo 'Version does not match. See version below:'
             ollama-cli --version
             exit 1


### PR DESCRIPTION
## What is the motivation for this pull request?

Update the integration test matrix to use `latest` instead of a hardcoded version (0.23.0), and add logic to resolve `latest` to the actual default version from `action.yml`.

## What is the current behavior?

The integration test matrix uses a hardcoded version `0.23.0` which needs to be manually updated when new Ollama versions are released.

## What is the new behavior?

- Changed matrix version from `0.23.0` to `latest`
- Added a "Get version" step that resolves `latest` to the default version from `action.yml` using cross-platform `sed` (works on Windows via Git Bash)
- Updated the version check to use `${{ env.VERSION }}` instead of `${{ matrix.version }}`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
